### PR TITLE
Add a custom event to capture frame before requestAnimationFrame

### DIFF
--- a/js/awe-standard.js
+++ b/js/awe-standard.js
@@ -4318,7 +4318,10 @@ if (params.background_image){
         TWEEN.update();
         this_awe.resize_canvas();
         this_awe.render();
-        
+	
+ 	var event = new CustomEvent('before_frame_render');
+        window.dispatchEvent(event);    
+    
         requestAnimationFrame(function() {
           var event = new CustomEvent('pretick');
           window.dispatchEvent(event);


### PR DESCRIPTION
I have added a CustomEvent `before_frame_render` just before  requestAnimationFrame. Reason is given bellow. 

I was trying to capture a frame and send it to sever using an ajax call. 
Initially, I tried to use `pretick` but it just gave me all pixel transparent frame, showing buffer was empty at that point. I then tried `tick` event and even that resulted in the same transparent image, again showing buffer was empty at that point too.

Adding an event just before `requestAnimationFrame` helped me capture the frame and send it to sever. 

I am still trying to understand the working of requestAnimationFrame and why pretick didn't do the trick. 
I assume pretick is just before it starts adding pixels to the frame and tick is just after it has removed pixels from the frame. 

The snippet I used to capture and send the frame :  

```javascript
var captureFrame = false;
//for doing something just before render
window.addEventListener('before_frame_render', function(){        
 if(window.captureFrame == true){
  if (captureFrame) {
        captureFrame = false;                      //captureFrame is false until the next click
        var awecanvas = document.getElementById('awe_canvas-0');
        awecanvas.getContext("webgl", {preserveDrawingBuffer: true}); //preserves the  buffer
        var dataURL = awecanvas.toDataURL();
         $.ajax({
          type: "POST",
          url: "saveImage.php",
          data: {
            imgBase64: dataURL,
            }
          }).done(function(str) {  // response 
          });
      }
    }
  });

//On click of capture button
 document.getElementById("capture").addEventListener("click", function(){ 
      captureFrame = true;
 });
```



